### PR TITLE
Creates fact_sales table

### DIFF
--- a/models/intermediate/int_fact__metrics.sql
+++ b/models/intermediate/int_fact__metrics.sql
@@ -1,0 +1,66 @@
+WITH
+    --Importing models from staging
+    order_details AS (
+        select *
+        from {{ ref('stg_erp__order_details') }}
+    )
+    , orders AS (
+        select *
+        from {{ ref('stg_erp__orders') }}
+    )
+    , joined AS (
+        select 
+            order_details.order_item_sk
+            , order_details.product_fk
+            , orders.customer_fk
+            , orders.employee_fk
+            , orders.shipper_fk
+            , orders.order_date
+            , orders.ship_date
+            , orders.required_delivery_date
+            , order_details.discount
+            , order_details.unit_price
+            , order_details.quantity
+            , orders.freight
+            , orders.order_number
+            , orders.recipient_name
+            , orders.recipient_city
+            , orders.recipient_region
+            , orders.recipient_country
+        from order_details
+        inner join orders ON order_details.order_fk = orders.order_pk
+    )
+    , metrics AS (
+        select 
+           order_item_sk
+           , product_fk
+           , customer_fk
+           , employee_fk
+           , shipper_fk
+           , order_date
+           , ship_date
+           , required_delivery_date
+           , unit_price
+           , quantity
+           , discount
+           , unit_price * quantity as gross_total
+           , unit_price * quantity * (1 - discount) as net_total
+           , CAST(
+                (freight / count(*) over (partition by order_number)) 
+             AS numeric(18,2)) as freight_allocated
+           , CASE 
+                WHEN discount > 0 THEN 'Yes'
+                ELSE 'No'
+             END AS had_discount
+           , order_number
+           , recipient_name
+           , recipient_city
+           , CASE
+                WHEN recipient_region IS NULL THEN 'N/A'
+                ELSE recipient_region
+             END AS recipient_region
+           , recipient_country 
+        from joined
+    )
+
+select * from metrics

--- a/models/marts/fact_sales.sql
+++ b/models/marts/fact_sales.sql
@@ -1,0 +1,7 @@
+WITH
+    int_fact AS (
+        select *
+        from {{ ref('int_fact__metrics') }}
+    )
+
+select * from int_fact

--- a/models/marts/fact_sales.yml
+++ b/models/marts/fact_sales.yml
@@ -1,0 +1,86 @@
+models:
+  - name: fact_sales
+    description: > 
+      This is a fact table that lists and stores information about orders at the order item level of granularity. 
+      The table includes foreign keys to be used for joining with dimension tables, date fields (such as order date), 
+      metrics (such as freight per item, gross revenue, and net revenue), and descriptive fields such as delivery vendor 
+      information. This fact table is derived from a join between the orders and order_details tables.
+    columns:
+      - name: order_item_sk
+        description: Unique identifier for each combination of order and order item.
+        tests:
+          - unique
+          - not_null
+
+      - name: product_fk
+        description: Foreign key that will be used to relate this table to the products table.
+        tests:
+          - relationships:
+              to: ref('dim_products')
+              field: product_pk
+
+      - name: customer_fk
+        description: Foreign key that will be used to relate this table to the customers table.
+        tests:
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_pk
+
+      - name: employee_fk
+        description: Foreign key that will be used to relate this table to the employees table.
+        tests:
+          - relationships:
+              to: ref('dim_employees')
+              field: employee_pk
+
+      - name: shipper_fk
+        description: Foreign key that will be used to relate this table to the shippers table.
+        tests:
+          - relationships:
+              to: ref('dim_shippers')
+              field: shipper_pk
+
+      - name: order_date
+        description: The date the order was placed.
+
+      - name: ship_date
+        description: The date the order was shipped.
+
+      - name: required_delivery_date
+        description: The date when the order is expected to be delivered.
+      
+      - name: unit_price
+        description: The unit price of the product.
+      
+      - name: quantity
+        description: The number of units of the product ordered.
+
+      - name: discount
+        description: The percentage discount applied to the product price.
+
+      - name: Gross total
+        description: Total amount before discount for the order item (unit price * quantity).
+
+      - name: net_total
+        description: Total amount after discount for the order item.
+
+      - name: freight_allocated
+        description: Freight cost allocated to the order item based on item count.
+
+      - name: had_discount
+        description: Indicates whether a discount was applied to the item.
+
+      - name: order_number
+        description: Human-readable identifier of the order.
+
+      - name: recipient_name
+        description: Name of the person or company receiving the order.
+
+      - name: recipient_city
+        description: City where the order was delivered.
+
+      - name: recipient_region
+        description: Region where the order was delivered.
+
+      - name: recipient_country
+        description: Country where the order was delivered.  


### PR DESCRIPTION
The fact_sales table was created as a result of a join between the order and order_details tables. In the intermediate layer, column enrichments and the creation of several metrics were performed, including gross_total, net_total, and allocated_shipping_cost. Additionally, documentation and tests were added in the fact_sales.yml file, covering uniqueness, not null, and foreign key constraints.