### PR TITLE
Creates shipping_status flag and customized tests for int_sales

### DIFF
--- a/models/intermediate/int_fact__metrics.sql
+++ b/models/intermediate/int_fact__metrics.sql
@@ -40,6 +40,10 @@ WITH
            , order_date
            , ship_date
            , required_delivery_date
+           , CASE 
+                WHEN ship_date > required_delivery_date THEN 'Late'
+                ELSE 'On time'
+             END AS shipping_status
            , unit_price
            , quantity
            , discount

--- a/models/marts/fact_sales.yml
+++ b/models/marts/fact_sales.yml
@@ -48,6 +48,12 @@ models:
 
       - name: required_delivery_date
         description: The date when the order is expected to be delivered.
+
+      - name: shipping_status
+        description: Indicates whether the order was shipped on time or late.
+        tests:
+          - accepted_values:
+              values: ['Late', 'On time']
       
       - name: unit_price
         description: The unit price of the product.

--- a/tests/tst_net_sales_1996_1998.sql
+++ b/tests/tst_net_sales_1996_1998.sql
@@ -1,0 +1,14 @@
+/*
+    This test ensures that the total net sales for years between 1996 and 1998 match
+    the audited accounting value: R$ 1,265,793.04
+*/
+
+with net_sales_1996_1998 as (
+    select sum(net_total) as total
+    from {{ ref('int_fact__metrics') }}
+    where order_date between '1996-01-01' and '1998-12-31'
+)
+
+select *
+from net_sales_1996_1998
+where total not between 1265793.01 and 1265793.07

--- a/tests/tst_total_sales_1996_1998.sql
+++ b/tests/tst_total_sales_1996_1998.sql
@@ -1,0 +1,14 @@
+/*
+    This test ensures that the gross sales for years between 1996 and 1998 match
+    the audited accounting value: R$ 1,354,458.59
+*/
+
+with sales_1996_1998 as (
+    select sum(gross_total) as total
+    from {{ ref('int_fact__metrics') }}
+    where order_date between '1996-01-01' and '1998-12-31'
+)
+
+select *
+from sales_1996_1998
+where total not between 1354458.56 and 1354458.62


### PR DESCRIPTION
Creates a flag column called shipping_status that checks if the shipping_date is later than the required_delivery_date. This flag indicates whether the order was shipped late.

Additionally, two custom tests are implemented to verify that the gross_total and net_total values in the fact_sales table match the audited values.